### PR TITLE
Remove newlines at end of syscall names

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ with open("syscall.txt", "r") as f:
     raw_syscall_list = f.readlines()
 
 syscalls = [syscall.split(". ") for syscall in raw_syscall_list]
-syscalls = {syscall[0]:syscall[1] for syscall in syscalls}
+syscalls = {syscall[0]:syscall[1].rstrip("\n") for syscall in syscalls}
 
 def on_message(message, _):
     thread_id, syscall_number = message["payload"].split(":")


### PR DESCRIPTION
Currently additional newlines are included at the end of each syscall name. This causes empty lines in the output which makes the output a bit harder to parse. Therefore this PR removes these newlines.

Please let me know if you want me to also update the README with example output.