### PR TITLE
Catch exception if device is not available

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,12 @@ def main(target: str) -> None:
             app_identifier: str = app.identifier
             break
 
-    pid = device.spawn([app_identifier])
+    try:
+        pid = device.spawn([app_identifier])
+    except frida.NotSupportedError as e:
+        print(e)
+        return
+
     session = device.attach(pid)
     session.on('detached', on_detached)
 


### PR DESCRIPTION
Catch exception if device is not available (e.g., when locked) and only show error message instead of whole backtrace.

Before:
```
Traceback (most recent call last):
  File "main.py", line 51, in <module>
    main(args.target)
  File "main.py", line 31, in main
    pid = device.spawn([app_identifier])
  File "/usr/local/lib/python3.7/site-packages/frida/core.py", line 26, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/frida/core.py", line 140, in spawn
    return self._impl.spawn(program, argv, envp, env, cwd, stdio, aux_options)
frida.NotSupportedError: unable to launch iOS app: The operation couldn’t be completed. Unable to launch de.starfinanz.pushTanApp because the device was not, or could not be, unlocked.
```

After:
```
unable to launch iOS app: The operation couldn’t be completed. Unable to launch de.starfinanz.pushTanApp because the device was not, or could not be, unlocked.
```